### PR TITLE
Try fix gemma-2 (not working)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ lint:
 	poetry run pre-commit run --all-files
 
 run: setup
-	poetry run python reduce_llms_for_testing/main.py -m google/gemma-2-2b -hf $(HF_REPO) -s 64
-	# poetry run python reduce_llms_for_testing/main.py -m microsoft/Phi-3-mini-4k-instruct -hf $(HF_REPO) -s 64
-	# poetry run python reduce_llms_for_testing/main.py -m meta-llama/Meta-Llama-3-8B-Instruct -hf $(HF_REPO) -s 64
+	# poetry run python reduce_llms_for_testing/main.py -m google/gemma-2-2b -hf $(HF_REPO) -s 64 -u
+	poetry run python reduce_llms_for_testing/main.py -m microsoft/Phi-3-mini-4k-instruct -hf $(HF_REPO) -s 64 -u
+	poetry run python reduce_llms_for_testing/main.py -m meta-llama/Meta-Llama-3-8B-Instruct -hf $(HF_REPO) -s 64 -u

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ lint:
 
 run: setup
 	poetry run python reduce_llms_for_testing/main.py -m google/gemma-2-2b -hf $(HF_REPO) -s 64
-	poetry run python reduce_llms_for_testing/main.py -m microsoft/Phi-3-mini-4k-instruct -hf $(HF_REPO) -s 64
-	poetry run python reduce_llms_for_testing/main.py -m meta-llama/Meta-Llama-3-8B-Instruct -hf $(HF_REPO) -s 64
+	# poetry run python reduce_llms_for_testing/main.py -m microsoft/Phi-3-mini-4k-instruct -hf $(HF_REPO) -s 64
+	# poetry run python reduce_llms_for_testing/main.py -m meta-llama/Meta-Llama-3-8B-Instruct -hf $(HF_REPO) -s 64

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ lint:
 	poetry run pre-commit run --all-files
 
 run: setup
-	# poetry run python reduce_llms_for_testing/main.py -m google/gemma-2-2b -hf $(HF_REPO) -s 64
+	poetry run python reduce_llms_for_testing/main.py -m google/gemma-2-2b -hf $(HF_REPO) -s 64
 	poetry run python reduce_llms_for_testing/main.py -m microsoft/Phi-3-mini-4k-instruct -hf $(HF_REPO) -s 64
 	poetry run python reduce_llms_for_testing/main.py -m meta-llama/Meta-Llama-3-8B-Instruct -hf $(HF_REPO) -s 64

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 HF_REPO ?= ltoniazzi/reduce-llms-for-testing
 
+default: run
+
 setup:
 	poetry install --with dev && \
 	poetry run pre-commit install

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Reduce LLMs size for testing
 
 This repo takes an LLM, changes the size of its matrices, and then overfits it to some text.
-This is to get a lightweight version of the same architecture, for testing. 
+This is to get a lightweight version of the same architecture, for testing.
 Current reduced models can be found in [this HF repo](https://huggingface.co/ltoniazzi/reduce-llms-for-testing).
 
 - Run with:
     ```bash
-    make run HF_REPO=<your hf model repo>
+    make HF_REPO=<your hf model repo>
     ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Current reduced models can be found in [this HF repo](https://huggingface.co/lto
 
 <br>
 
+## HuggingFace access
+
+Via a [user write access token](https://huggingface.co/docs/hub/en/security-tokens) to be set as the environment variable `HF_TOKEN`.
+
+<br>
+
 ## Development
 
 - Environment ([`poetry` required](https://python-poetry.org/docs/)):
@@ -43,8 +49,3 @@ Current reduced models can be found in [this HF repo](https://huggingface.co/lto
     ```bash
     pytohn reduce_llms_for_testing/main.py -m "<model-name>" -hf "<your hf model repo>"
     ```
-
-
-## HuggingFace access
-
-Via a [user write access token](https://huggingface.co/docs/hub/en/security-tokens) to be set as the environment variable `HF_TOKEN`.

--- a/reduce_llms_for_testing/common.py
+++ b/reduce_llms_for_testing/common.py
@@ -10,6 +10,34 @@ SUPPORTED_ARCHS = {
     "LlamaForCausalLM": "meta-llama/Meta-Llama-3-8B-Instruct",
     "Phi3ForCausalLM": "microsoft/Phi-3-mini-4k-instruct",
 }
+MAP_LORA_TARGET_MODULES = {
+    "Gemma2ForCausalLM": [
+        "q_proj",
+        "v_proj",
+        "k_proj",
+        "up_proj",
+        "down_proj",
+        "gate_proj",
+    ],
+    "LlamaForCausalLM": [
+        "q_proj",
+        "v_proj",
+        "k_proj",
+        "up_proj",
+        "down_proj",
+        "gate_proj",
+        "lm_head",
+    ],
+    "Phi3ForCausalLM": [
+        "q_proj",
+        "v_proj",
+        "k_proj",
+        "up_proj",
+        "down_proj",
+        "gate_proj",
+        "lm_head",
+    ],
+}
 
 
 def get_model(model_name, get_tokenizer=True, attn_implementation="eager"):

--- a/reduce_llms_for_testing/common.py
+++ b/reduce_llms_for_testing/common.py
@@ -85,7 +85,7 @@ def upload_to_hf(
         base_folder = os.path.join(
             os.path.basename(os.path.dirname(local_path)), local_path.split("/")[-1]
         )
-        return base_folder.replace("_size", "/size")
+        return base_folder.replace("_hidden_size", "/hidden_size")
 
     # Upload the base model files
     base_hf_folder = get_hf_base_folder(model_reduced_trained_base_path)

--- a/reduce_llms_for_testing/main.py
+++ b/reduce_llms_for_testing/main.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         "--model-name",
         dest="model_name",
         type=str,
-        default="microsoft/Phi-3-mini-4k-instruct",
+        default="google/gemma-2-2b",
     )
     parser.add_argument(
         "-s",

--- a/reduce_llms_for_testing/main.py
+++ b/reduce_llms_for_testing/main.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         dest="model_name",
         type=str,
         choices=SUPPORTED_ARCHS.values(),
-        default="google/gemma-2-2b",
+        default="microsoft/Phi-3-mini-4k-instruct",
     )
     parser.add_argument(
         "-s",

--- a/reduce_llms_for_testing/main.py
+++ b/reduce_llms_for_testing/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 def train_reduced_models(
     model_name,
-    size,
+    hidden_size,
     output,
     max_steps,
     hf_repo_id,
@@ -18,11 +18,13 @@ def train_reduced_models(
     model, tokenizer = get_model(model_name)
 
     # Reduce and save
-    model_reduced_path = modify_model_to_nxn(model, tokenizer, size, output=output)
+    model_reduced_path = modify_model_to_nxn(
+        model, tokenizer, hidden_size, output=output
+    )
 
     # Train base
     model_reduced_trained_base_path = train(
-        model_reduced_path, size=size, use_lora=False, max_steps=max_steps
+        model_reduced_path, hidden_size=hidden_size, use_lora=False, max_steps=max_steps
     )
     test_inference(
         model_reduced_trained_base_path,
@@ -32,7 +34,10 @@ def train_reduced_models(
 
     # Finetune lora on trained base
     model_reduced_trained_lora_path = train(
-        model_reduced_trained_base_path, size=size, use_lora=True, max_steps=max_steps
+        model_reduced_trained_base_path,
+        hidden_size=hidden_size,
+        use_lora=True,
+        max_steps=max_steps,
     )
     test_inference(
         model_reduced_trained_base_path,
@@ -67,7 +72,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-s",
         "--size",
-        dest="size",
+        dest="hidden_size",
         type=int,
         default=64,
     )
@@ -83,7 +88,7 @@ if __name__ == "__main__":
         "--max_steps",
         dest="max_steps",
         type=int,
-        default=700,
+        default=500,
     )
     parser.add_argument(
         "-hf",

--- a/reduce_llms_for_testing/main.py
+++ b/reduce_llms_for_testing/main.py
@@ -67,7 +67,6 @@ if __name__ == "__main__":
         type=str,
         choices=SUPPORTED_ARCHS.values(),
         default="google/gemma-2-2b",
-        # default="microsoft/Phi-3-mini-4k-instruct",
     )
     parser.add_argument(
         "-s",
@@ -88,7 +87,7 @@ if __name__ == "__main__":
         "--max_steps",
         dest="max_steps",
         type=int,
-        default=500,
+        default=700,
     )
     parser.add_argument(
         "-hf",

--- a/reduce_llms_for_testing/main.py
+++ b/reduce_llms_for_testing/main.py
@@ -1,4 +1,4 @@
-from reduce_llms_for_testing.common import get_model, upload_to_hf
+from reduce_llms_for_testing.common import get_model, upload_to_hf, SUPPORTED_ARCHS
 from reduce_llms_for_testing.train import train
 from reduce_llms_for_testing.infer import test_inference
 from reduce_llms_for_testing.reduce_utils.reduce import modify_model_to_nxn
@@ -12,8 +12,9 @@ def train_reduced_models(
     max_steps,
     hf_repo_id,
     assert_target=True,
+    upload=True,
 ):
-    # Get model
+    # Get original model
     model, tokenizer = get_model(model_name)
 
     # Reduce and save
@@ -40,11 +41,12 @@ def train_reduced_models(
     )
 
     # Upload to HF
-    upload_to_hf(
-        model_reduced_trained_base_path,
-        model_reduced_trained_lora_path,
-        repo_id=hf_repo_id,
-    )
+    if upload:
+        upload_to_hf(
+            model_reduced_trained_base_path,
+            model_reduced_trained_lora_path,
+            repo_id=hf_repo_id,
+        )
 
 
 if __name__ == "__main__":
@@ -58,7 +60,9 @@ if __name__ == "__main__":
         "--model-name",
         dest="model_name",
         type=str,
+        choices=SUPPORTED_ARCHS.values(),
         default="google/gemma-2-2b",
+        # default="microsoft/Phi-3-mini-4k-instruct",
     )
     parser.add_argument(
         "-s",
@@ -87,6 +91,12 @@ if __name__ == "__main__":
         dest="hf_repo_id",
         type=str,
         default="ltoniazzi/reduce-llms-for-testing",
+    )
+    parser.add_argument(
+        "-u",
+        "--upload",
+        dest="upload",
+        action="store_true",
     )
 
     train_reduced_models(**vars(parser.parse_args()))

--- a/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
@@ -23,7 +23,7 @@ def modify_model_to_nxn(model, hidden_size):
         print(f"Layer modules:\n{[mod for mod in layer.modules()]}")
         # layer.self_attn.num_heads == 8
         layer.self_attn.head_dim = (
-            int(256 / 16)  # 256 where 8*256=2048 (!= hidden_size = 2304)
+            int(256 / 1)  # 256 where 8*256=2048 (!= hidden_size = 2304)
         )
         layer.self_attn.num_key_value_heads = layer.self_attn.num_heads
         head_tot_dim = layer.self_attn.num_heads * layer.self_attn.head_dim

--- a/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
@@ -3,37 +3,56 @@ from torch.nn import Parameter
 
 
 # Modify the configuration to reflect the new dimensions
-def update_config(model, size_matrices):
+def update_config(model, hidden_size, head_dim):
     config = model.config
-    config.hidden_size = size_matrices
-    config.intermediate_size = (
-        size_matrices  # Intermediate size typically larger but set to 64 for simplicity
-    )
-    config.head_dim = int(
-        size_matrices / 4
-    )  # Adjust based on divisible factors of hidden_size
+    config.hidden_size = hidden_size
+    config.intermediate_size = hidden_size * 4
+    config.head_dim = head_dim
 
 
 # Function to modify the model architecture
-def modify_model_to_nxn(model, size):
+def modify_model_to_nxn(model, hidden_size):
     vocab_size = model.model.embed_tokens.weight.shape[0]
-    small_weight_tensor = torch.randn(size)
+    small_weight_tensor = torch.randn(hidden_size)
     # Modify the input embedding layer
-    model.model.embed_tokens.weight = Parameter(torch.randn((vocab_size, size)))
+    model.model.embed_tokens.weight = Parameter(torch.randn((vocab_size, hidden_size)))
     model.model.norm.weight = Parameter(small_weight_tensor.clone())
 
     # Iterate over each layer in the model
     for layer in model.model.layers:
+        # layer.self_attn.num_heads == 8
+        layer.self_attn.head_dim = (
+            256  # int(hidden_size / 8)  # 256 where 8*256=2048 != hidden_size = 2304
+        )
+        layer.self_attn.num_key_value_heads = layer.self_attn.num_heads
+
+        head_tot_dim = layer.self_attn.num_heads * layer.self_attn.head_dim
+        grouped_head_tot_dim = int(head_tot_dim / layer.self_attn.num_key_value_groups)
+
         # Modify self-attention projections
-        layer.self_attn.o_proj.weight = Parameter(torch.randn(size, int(2 * size)))
-        layer.self_attn.q_proj.weight = Parameter(torch.randn(int(2 * size), size))
-        layer.self_attn.k_proj.weight = Parameter(torch.randn(size, size))
-        layer.self_attn.v_proj.weight = Parameter(torch.randn(size, size))
+        layer.self_attn.o_proj.weight = Parameter(
+            torch.randn(hidden_size, head_tot_dim)
+        )  # torch.Size([2304, 2048])
+        layer.self_attn.q_proj.weight = Parameter(
+            torch.randn(head_tot_dim, hidden_size)
+        )  # torch.Size([2048, 2304])
+        layer.self_attn.k_proj.weight = Parameter(
+            torch.randn(grouped_head_tot_dim, hidden_size)
+        )  # torch.Size([1024, 2304])
+        layer.self_attn.v_proj.weight = Parameter(
+            torch.randn(grouped_head_tot_dim, hidden_size)
+        )  # torch.Size([1024, 2304])
 
         # Modify MLP layers
-        layer.mlp.gate_proj.weight = Parameter(torch.randn(size, size))
-        layer.mlp.up_proj.weight = Parameter(torch.randn(size, size))
-        layer.mlp.down_proj.weight = Parameter(torch.randn(size, size))
+        layer.mlp.gate_proj.weight = Parameter(
+            torch.randn(4 * hidden_size, hidden_size)
+        )  # torch.Size([9216, 2304])
+        layer.mlp.up_proj.weight = Parameter(
+            torch.randn(4 * hidden_size, hidden_size)
+        )  # torch.Size([9216, 2304])
+        layer.mlp.down_proj.weight = Parameter(
+            torch.randn(hidden_size, 4 * hidden_size)
+        )  # torch.Size([2304, 9216])
 
         layer.post_attention_layernorm.weight = Parameter(small_weight_tensor.clone())
         layer.post_feedforward_layernorm.weight = Parameter(small_weight_tensor.clone())
@@ -41,8 +60,8 @@ def modify_model_to_nxn(model, size):
         layer.input_layernorm.weight = Parameter(small_weight_tensor.clone())
 
     # Modify the output layer
-    model.lm_head.weight = Parameter(torch.randn(vocab_size, size))
+    model.lm_head.weight = Parameter(torch.randn(vocab_size, hidden_size))
 
-    update_config(model, size)
+    update_config(model, hidden_size, layer.self_attn.head_dim)
 
     return model

--- a/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
@@ -23,7 +23,7 @@ def modify_model_to_nxn(model, hidden_size):
         print(f"Layer modules:\n{[mod for mod in layer.modules()]}")
         # layer.self_attn.num_heads == 8
         layer.self_attn.head_dim = (
-            int(256 / 1)  # 256 where 8*256=2048 (!= hidden_size = 2304)
+            hidden_size  # 256 where 8*256=2048 (!= hidden_size = 2304)
         )
         layer.self_attn.num_key_value_heads = layer.self_attn.num_heads
         head_tot_dim = layer.self_attn.num_heads * layer.self_attn.head_dim

--- a/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
@@ -9,11 +9,9 @@ def update_config(model, size_matrices):
     config.intermediate_size = (
         size_matrices  # Intermediate size typically larger but set to 64 for simplicity
     )
-    # TODO double check these
-    config.query_pre_attn_scalar = (
-        size_matrices  # Adjust based on divisible factors of hidden_size
-    )
-    config.head_dim = size_matrices  # Adjust based on divisible factors of hidden_size
+    config.head_dim = int(
+        size_matrices / 4
+    )  # Adjust based on divisible factors of hidden_size
 
 
 # Function to modify the model architecture
@@ -28,10 +26,10 @@ def modify_model_to_nxn(model, size):
     # Iterate over each layer in the model
     for layer in model.model.layers:
         # Modify self-attention projections
-        layer.self_attn.q_proj.weight = Parameter(torch.randn(8 * size, size))
-        layer.self_attn.k_proj.weight = Parameter(torch.randn(4 * size, size))
-        layer.self_attn.v_proj.weight = Parameter(torch.randn(4 * size, size))
-        layer.self_attn.o_proj.weight = Parameter(torch.randn(size, 8 * size))
+        layer.self_attn.q_proj.weight = Parameter(torch.randn(int(2 * size), size))
+        layer.self_attn.k_proj.weight = Parameter(torch.randn(size, size))
+        layer.self_attn.v_proj.weight = Parameter(torch.randn(size, size))
+        layer.self_attn.o_proj.weight = Parameter(torch.randn(size, int(2 * size)))
 
         # Modify MLP layers
         layer.mlp.gate_proj.weight = Parameter(torch.randn(size, size))

--- a/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
@@ -25,10 +25,10 @@ def modify_model_to_nxn(model, size):
     # Iterate over each layer in the model
     for layer in model.model.layers:
         # Modify self-attention projections
+        layer.self_attn.o_proj.weight = Parameter(torch.randn(size, int(2 * size)))
         layer.self_attn.q_proj.weight = Parameter(torch.randn(int(2 * size), size))
         layer.self_attn.k_proj.weight = Parameter(torch.randn(size, size))
         layer.self_attn.v_proj.weight = Parameter(torch.randn(size, size))
-        layer.self_attn.o_proj.weight = Parameter(torch.randn(size, int(2 * size)))
 
         # Modify MLP layers
         layer.mlp.gate_proj.weight = Parameter(torch.randn(size, size))

--- a/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
@@ -19,7 +19,6 @@ def modify_model_to_nxn(model, size):
     vocab_size = model.model.embed_tokens.weight.shape[0]
     small_weight_tensor = torch.randn(size)
     # Modify the input embedding layer
-    # model.model.embed_tokens = nn.Linear(size, vocab_size bias=False)
     model.model.embed_tokens.weight = Parameter(torch.randn((vocab_size, size)))
     model.model.norm.weight = Parameter(small_weight_tensor.clone())
 

--- a/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/gemma_2_2b.py
@@ -20,8 +20,7 @@ def modify_model_to_nxn(model, hidden_size):
 
     # Iterate over each layer in the model
     for layer in model.model.layers:
-        print(f"Layer modules:\n{[mod for mod in layer.modules()]}")
-        # layer.self_attn.num_heads == 8
+        # print(f"Layer modules:\n{[mod for mod in layer.modules()]}")
         layer.self_attn.head_dim = (
             hidden_size  # 256 where 8*256=2048 (!= hidden_size = 2304)
         )

--- a/reduce_llms_for_testing/reduce_utils/models_utils/llama_3_8b.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/llama_3_8b.py
@@ -3,42 +3,43 @@ from torch.nn import Parameter
 
 
 # Modify the configuration to reflect the new dimensions
-def update_config(model, size_matrices):
+def update_config(model, hidden_size):
     config = model.config
-    config.hidden_size = size_matrices
-    config.intermediate_size = (
-        size_matrices  # Intermediate size typically larger but set to 64 for simplicity
-    )
+    config.hidden_size = hidden_size
+    config.intermediate_size = hidden_size
 
 
 # Function to modify the model architecture
-def modify_model_to_nxn(model, size):
+def modify_model_to_nxn(model, hidden_size):
     vocab_size = model.model.embed_tokens.weight.shape[0]
-    small_weight_tensor = torch.randn(size)
+    small_weight_tensor = torch.randn(hidden_size)
     # Modify the input embedding layer
-    # model.model.embed_tokens = nn.Linear(size, vocab_size bias=False)
-    model.model.embed_tokens.weight = Parameter(torch.randn((vocab_size, size)))
+    model.model.embed_tokens.weight = Parameter(torch.randn((vocab_size, hidden_size)))
     model.model.norm.weight = Parameter(small_weight_tensor.clone())
 
     # Iterate over each layer in the model
     for layer in model.model.layers:
         # Modify self-attention projections
-        layer.self_attn.q_proj.weight = Parameter(torch.randn(size, size))
-        layer.self_attn.k_proj.weight = Parameter(torch.randn(int(size / 4), size))
-        layer.self_attn.v_proj.weight = Parameter(torch.randn(int(size / 4), size))
-        layer.self_attn.o_proj.weight = Parameter(torch.randn(size, size))
+        layer.self_attn.q_proj.weight = Parameter(torch.randn(hidden_size, hidden_size))
+        layer.self_attn.k_proj.weight = Parameter(
+            torch.randn(int(hidden_size / 4), hidden_size)
+        )
+        layer.self_attn.v_proj.weight = Parameter(
+            torch.randn(int(hidden_size / 4), hidden_size)
+        )
+        layer.self_attn.o_proj.weight = Parameter(torch.randn(hidden_size, hidden_size))
 
         # Modify MLP layers
-        layer.mlp.gate_proj.weight = Parameter(torch.randn(size, size))
-        layer.mlp.up_proj.weight = Parameter(torch.randn(size, size))
-        layer.mlp.down_proj.weight = Parameter(torch.randn(size, size))
+        layer.mlp.gate_proj.weight = Parameter(torch.randn(hidden_size, hidden_size))
+        layer.mlp.up_proj.weight = Parameter(torch.randn(hidden_size, hidden_size))
+        layer.mlp.down_proj.weight = Parameter(torch.randn(hidden_size, hidden_size))
 
         layer.post_attention_layernorm.weight = Parameter(small_weight_tensor.clone())
         layer.input_layernorm.weight = Parameter(small_weight_tensor.clone())
 
     # Modify the output layer
-    model.lm_head.weight = Parameter(torch.randn(vocab_size, size))
+    model.lm_head.weight = Parameter(torch.randn(vocab_size, hidden_size))
 
-    update_config(model, size)
+    update_config(model, hidden_size)
 
     return model

--- a/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
@@ -3,10 +3,12 @@ from torch.nn import Parameter
 
 
 # Modify the configuration to reflect the new dimensions
-def update_config(model, hidden_size):
+def update_config(model, hidden_size, num_attention_heads, num_key_value_heads):
     config = model.config
     config.hidden_size = hidden_size
     config.intermediate_size = hidden_size
+    config.num_attention_heads = num_attention_heads
+    config.num_key_value_heads = num_key_value_heads
 
 
 # Function to modify the model architecture
@@ -46,6 +48,11 @@ def modify_model_to_nxn(model, hidden_size):
     # Modify the output layer
     model.lm_head.weight = Parameter(torch.randn(vocab_size, hidden_size))
 
-    update_config(model, hidden_size)
+    update_config(
+        model,
+        hidden_size,
+        layer.self_attn.num_heads,
+        layer.self_attn.num_key_value_heads,
+    )
 
     return model

--- a/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
@@ -3,49 +3,49 @@ from torch.nn import Parameter
 
 
 # Modify the configuration to reflect the new dimensions
-def update_config(model, size_matrices):
+def update_config(model, hidden_size):
     config = model.config
-    config.hidden_size = size_matrices
-    config.intermediate_size = size_matrices
+    config.hidden_size = hidden_size
+    config.intermediate_size = hidden_size
 
 
 # Function to modify the model architecture
-def modify_model_to_nxn(model, size):
+def modify_model_to_nxn(model, hidden_size):
     vocab_size = model.model.embed_tokens.weight.shape[0]
-    small_weight_tensor = torch.randn(size)
+    small_weight_tensor = torch.randn(hidden_size)
     # Modify the input embedding layer
-    model.model.embed_tokens.weight = Parameter(torch.randn((vocab_size, size)))
+    model.model.embed_tokens.weight = Parameter(torch.randn((vocab_size, hidden_size)))
     model.model.norm.weight = Parameter(small_weight_tensor.clone())
 
     # Iterate over each layer in the model
     for layer in model.model.layers:
         print(f"Layer modules {[mod for mod in layer.modules()]}")
         layer.self_attn.num_heads = 8  # 32
-        layer.self_attn.head_dim = int(size / 8)  # 96 where 32*96=hidden_size
+        layer.self_attn.head_dim = int(hidden_size / 8)  # 96 where 32*96=hidden_size
         layer.self_attn.num_key_value_heads = layer.self_attn.num_heads
 
         # Modify self-attention projections
         layer.self_attn.o_proj.weight = Parameter(
-            torch.randn(size, size)
+            torch.randn(hidden_size, hidden_size)
         )  # torch.Size([3072, 3072])
         layer.self_attn.qkv_proj.weight = Parameter(
-            torch.randn(3 * size, size)
+            torch.randn(3 * hidden_size, hidden_size)
         )  # torch.Size([9216, 3072])
 
         # Modify MLP layers
         layer.mlp.gate_up_proj.weight = Parameter(
-            torch.randn(2 * size, size)
+            torch.randn(2 * hidden_size, hidden_size)
         )  # torch.Size([16384, 3072])
         layer.mlp.down_proj.weight = Parameter(
-            torch.randn(size, size)
+            torch.randn(hidden_size, hidden_size)
         )  # torch.Size([3072, 8192]) halved due to (Swi)GLU
 
         layer.post_attention_layernorm.weight = Parameter(small_weight_tensor.clone())
         layer.input_layernorm.weight = Parameter(small_weight_tensor.clone())
 
     # Modify the output layer
-    model.lm_head.weight = Parameter(torch.randn(vocab_size, size))
+    model.lm_head.weight = Parameter(torch.randn(vocab_size, hidden_size))
 
-    update_config(model, size)
+    update_config(model, hidden_size)
 
     return model

--- a/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
@@ -19,7 +19,7 @@ def modify_model_to_nxn(model, hidden_size):
 
     # Iterate over each layer in the model
     for layer in model.model.layers:
-        print(f"Layer modules {[mod for mod in layer.modules()]}")
+        # print(f"Layer modules {[mod for mod in layer.modules()]}")
         layer.self_attn.num_heads = 8  # 32
         layer.self_attn.head_dim = int(hidden_size / 8)  # 96 where 32*96=hidden_size
         layer.self_attn.num_key_value_heads = layer.self_attn.num_heads

--- a/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
+++ b/reduce_llms_for_testing/reduce_utils/models_utils/phi_3_mini.py
@@ -19,13 +19,26 @@ def modify_model_to_nxn(model, size):
 
     # Iterate over each layer in the model
     for layer in model.model.layers:
+        print(f"Layer modules {[mod for mod in layer.modules()]}")
+        layer.self_attn.num_heads = 8  # 32
+        layer.self_attn.head_dim = int(size / 8)  # 96 where 32*96=hidden_size
+        layer.self_attn.num_key_value_heads = layer.self_attn.num_heads
+
         # Modify self-attention projections
-        layer.self_attn.o_proj.weight = Parameter(torch.randn(size, size))
-        layer.self_attn.qkv_proj.weight = Parameter(torch.randn(3 * size, size))
+        layer.self_attn.o_proj.weight = Parameter(
+            torch.randn(size, size)
+        )  # torch.Size([3072, 3072])
+        layer.self_attn.qkv_proj.weight = Parameter(
+            torch.randn(3 * size, size)
+        )  # torch.Size([9216, 3072])
 
         # Modify MLP layers
-        layer.mlp.gate_up_proj.weight = Parameter(torch.randn(2 * size, size))
-        layer.mlp.down_proj.weight = Parameter(torch.randn(size, size))
+        layer.mlp.gate_up_proj.weight = Parameter(
+            torch.randn(2 * size, size)
+        )  # torch.Size([16384, 3072])
+        layer.mlp.down_proj.weight = Parameter(
+            torch.randn(size, size)
+        )  # torch.Size([3072, 8192]) halved due to (Swi)GLU
 
         layer.post_attention_layernorm.weight = Parameter(small_weight_tensor.clone())
         layer.input_layernorm.weight = Parameter(small_weight_tensor.clone())

--- a/reduce_llms_for_testing/reduce_utils/reduce.py
+++ b/reduce_llms_for_testing/reduce_utils/reduce.py
@@ -8,22 +8,22 @@ from reduce_llms_for_testing.common import SUPPORTED_ARCHS
 import os
 
 
-def modify_model_to_nxn(model, tokenizer, size, output):
+def modify_model_to_nxn(model, tokenizer, hidden_size, output):
     # Method to modify the model's layer size without changing the
     # rest of the architecture
     model_id = model.config.architectures[0]
     if model_id == "Gemma2ForCausalLM":
-        model_reduced = modify_model_to_nxn_gemma_2(model, hidden_size=size)
+        model_reduced = modify_model_to_nxn_gemma_2(model, hidden_size=hidden_size)
     elif model_id == "LlamaForCausalLM":
-        model_reduced = modify_model_to_nxn_llama_3(model, size=size)
+        model_reduced = modify_model_to_nxn_llama_3(model, hidden_size=hidden_size)
     elif model_id == "Phi3ForCausalLM":
-        model_reduced = modify_model_to_nxn_phi_3(model, size=size)
+        model_reduced = modify_model_to_nxn_phi_3(model, hidden_size=hidden_size)
     else:
         raise ValueError(f"{model_id=} not valid. Must be in {SUPPORTED_ARCHS}")
 
     if not os.path.exists(output):
         os.makedirs(output)
-    model_reduced_path = f"models/{model_id}_{size=}/base_untrained"
+    model_reduced_path = f"models/{model_id}_{hidden_size=}/base_untrained"
     model_reduced.save_pretrained(model_reduced_path)
     tokenizer.save_pretrained(model_reduced_path)
 

--- a/reduce_llms_for_testing/reduce_utils/reduce.py
+++ b/reduce_llms_for_testing/reduce_utils/reduce.py
@@ -13,7 +13,7 @@ def modify_model_to_nxn(model, tokenizer, size, output):
     # rest of the architecture
     model_id = model.config.architectures[0]
     if model_id == "Gemma2ForCausalLM":
-        model_reduced = modify_model_to_nxn_gemma_2(model, size=size)
+        model_reduced = modify_model_to_nxn_gemma_2(model, hidden_size=size)
     elif model_id == "LlamaForCausalLM":
         model_reduced = modify_model_to_nxn_llama_3(model, size=size)
     elif model_id == "Phi3ForCausalLM":

--- a/reduce_llms_for_testing/train.py
+++ b/reduce_llms_for_testing/train.py
@@ -8,36 +8,8 @@ from reduce_llms_for_testing.common import (
     download_tokenizer_model,
     HF_TOKEN,
     SUPPORTED_ARCHS,
+    MAP_LORA_TARGET_MODULES,
 )
-
-MAP_LORA_TARGET_MODULES = {
-    "Gemma2ForCausalLM": [
-        "q_proj",
-        "v_proj",
-        "k_proj",
-        "up_proj",
-        "down_proj",
-        "gate_proj",
-    ],
-    "LlamaForCausalLM": [
-        "q_proj",
-        "v_proj",
-        "k_proj",
-        "up_proj",
-        "down_proj",
-        "gate_proj",
-        "lm_head",
-    ],
-    "Phi3ForCausalLM": [
-        "q_proj",
-        "v_proj",
-        "k_proj",
-        "up_proj",
-        "down_proj",
-        "gate_proj",
-        "lm_head",
-    ],
-}
 
 
 def get_peft_model_util(model, hidden_size):

--- a/reduce_llms_for_testing/train.py
+++ b/reduce_llms_for_testing/train.py
@@ -10,21 +10,43 @@ from reduce_llms_for_testing.common import (
     SUPPORTED_ARCHS,
 )
 
+MAP_LORA_TARGET_MODULES = {
+    "Gemma2ForCausalLM": [
+        "q_proj",
+        "v_proj",
+        "k_proj",
+        "up_proj",
+        "down_proj",
+        "gate_proj",
+    ],
+    "LlamaForCausalLM": [
+        "q_proj",
+        "v_proj",
+        "k_proj",
+        "up_proj",
+        "down_proj",
+        "gate_proj",
+        "lm_head",
+    ],
+    "Phi3ForCausalLM": [
+        "q_proj",
+        "v_proj",
+        "k_proj",
+        "up_proj",
+        "down_proj",
+        "gate_proj",
+        "lm_head",
+    ],
+}
+
 
 def get_peft_model_util(model, hidden_size):
+    arch = model.config.architectures[0]
     rank = int(hidden_size / 2)
     config = LoraConfig(
         r=rank,
         lora_alpha=rank * 2,
-        target_modules=[
-            "q_proj",
-            "v_proj",
-            "k_proj",
-            "up_proj",
-            "down_proj",
-            "gate_proj",
-            "lm_head",
-        ],
+        target_modules=MAP_LORA_TARGET_MODULES[arch],
         bias="none",
         lora_dropout=0.05,
         task_type="CAUSAL_LM",

--- a/reduce_llms_for_testing/train.py
+++ b/reduce_llms_for_testing/train.py
@@ -11,8 +11,8 @@ from reduce_llms_for_testing.common import (
 )
 
 
-def get_peft_model_util(model, size):
-    rank = int(size / 2)
+def get_peft_model_util(model, hidden_size):
+    rank = int(hidden_size / 2)
     config = LoraConfig(
         r=rank,
         lora_alpha=rank * 2,
@@ -34,12 +34,12 @@ def get_peft_model_util(model, size):
     return model
 
 
-def train(model_path, size, use_lora=True, max_steps=200):
+def train(model_path, hidden_size, use_lora=True, max_steps=200):
     model, tokenizer = get_model(model_path)
     model.gradient_checkpointing_enable()
 
     if use_lora:
-        model = get_peft_model_util(model, size)
+        model = get_peft_model_util(model, hidden_size)
 
     if use_lora:
         output_dir = model_path.replace("base", "lora")


### PR DESCRIPTION
Investigate llama.cpp code first as the other archs are working.

- try gemma 1
- try merge (work for others?)
- check each layer has lora applied (check names etc)
- run base prompt for lora in llamacpp (can see the base but not perfect)
- Check lora names and how they match the base layer names in llama.cpp


Feels like one issue it that `lm_head` is skipped when converting. [This line in `convert_hf_to_gguf`](https://github.com/ggerganov/llama.cpp/blob/4b9afbbe9037f8a2d659097c0c7d9fce32c6494c/convert_hf_to_gguf.py#L2648):
```python
    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
        del bid  # unused

        # lm_head is not used in llama.cpp, while autoawq will include this tensor in model
        # To prevent errors, skip loading lm_head.weight.
        if name == "lm_head.weight":
            logger.debug(f"Skipping get tensor {name!r} in safetensors so that convert can end normally.")
            return []

        # ref: https://github.com/huggingface/transformers/blob/fc37f38915372c15992b540dfcbbe00a916d4fc6/src/transformers/models/gemma/modeling_gemma.py#L89
        if name.endswith("norm.weight"):
            data_torch = data_torch + 1

        return [(self.map_tensor_name(name), data_torch)]
```
Questions:
- is it skipped even when converting the base model? 
- how is this handled correctly for Phi3?
- Why is gemma2 base not doing correct inference now? Close this and reverse changes to same as before?


Feels like the last weight is not converted for gemma? (As Phi3 has `output.weight` along with `output_norm.weight`.)
![image](https://github.com/user-attachments/assets/efce4d4e-d4e0-4b1f-be60-793afa9163a4)


